### PR TITLE
digest-auth.rkt: nonce has \r\n

### DIFF
--- a/web-server-lib/web-server/http/digest-auth.rkt
+++ b/web-server-lib/web-server/http/digest-auth.rkt
@@ -2,6 +2,7 @@
 (require racket/port
          racket/match
          racket/contract
+         racket/string
          net/base64
          file/md5
          web-server/http/request-structs)
@@ -20,7 +21,7 @@
    #"WWW-Authenticate" 
    (string->bytes/utf-8
     (format "Digest realm=\"~a\", qop=\"auth\", nonce=\"~a\" opaque=\"~a\""
-            realm nonce opaque))))
+            realm (string-trim (bytes->string/utf-8 nonce)) opaque))))
 
 ;; Receiving
 (require parser-tools/lex


### PR DESCRIPTION
See message posted to racket users list today (2015-05-07).

`nonce` is generated with a `\r\n`, which makes for an invalid header. e.g.

```
(header
 #"WWW-Authenticate"
 #"Digest realm=\"my realm\", qop=\"auth\", nonce=\"MTQzMTAxNDc3NiBlNjFmMDY2NzgyYjcyNmFjMmIzY2RkNWQxOTU3NzIzNQ==\r\n\" opaque=\"opaque\"")
```

Patch trims the whitespace which must be the `\r\n` from the nonce.
- Is this use of `(string-trim (bytes->string/utf-8 nonce))` the best approach?
- Should there be a comma `","` before `opaque=...`
